### PR TITLE
feat: display referent name on order summary

### DIFF
--- a/tumeplay-app/src/screens/tunnel/TunnelCartSummary.js
+++ b/tumeplay-app/src/screens/tunnel/TunnelCartSummary.js
@@ -308,6 +308,8 @@ export default function TunnelCartSummary(props) {
             {(deliveryType == 'referent-metropole' ||
               deliveryType === 'referent-guyane') && (
               <Text style={[TunnelCartSummaryStyle.subTitle]}>
+								{selectedReferent.name}
+								{'\n'}
                 {selectedReferent.address}
                 {'\n'}
                 {selectedReferent.address_zipcode}{' '}


### PR DESCRIPTION
Fix commandes bugs :

- [ ] Afficher le nom du référent dans l'écran résumé de la commande
- [ ] La région n'est pas enregistrée pour les référents
- [ ] Les régions sont enregistré dans d'autres langues
- [ ] Commande reçus dans des départements invalides